### PR TITLE
Install tensorflow-cpu from pip instead of Anaconda

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,9 @@ MAINTAINER LSIT Systems <lsitops@lsit.ucsb.edu>
 
 USER root
 
-RUN mamba install -y nltk networkx tensorflow-cpu plotly pymupdf dlib spacy
+RUN pip install tensorflow-cpu
+
+RUN mamba install -y nltk networkx plotly pymupdf dlib spacy
 
 RUN pip install deepface gensim
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,10 +4,8 @@ MAINTAINER LSIT Systems <lsitops@lsit.ucsb.edu>
 
 USER root
 
-RUN pip install tensorflow-cpu
+RUN pip install deepface gensim tensorflow-cpu
 
 RUN mamba install -y nltk networkx plotly pymupdf dlib spacy
-
-RUN pip install deepface gensim
 
 USER $NB_USER


### PR DESCRIPTION
Fixes conda forge problem for tensorflow:

```
Pinned packages:

  - python=3.13

Pinned packages:

  - python=3.13

error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ pin on python =3.13 * is installable and it requires
    │  └─ python =3.13 *, which can be installed;
    └─ tensorflow-cpu =* * is not installable because there are no viable options
       ├─ tensorflow-cpu [2.10.0|2.11.0|...|2.9.1] would require
       │  └─ tensorflow [==2.10.0 cpu_py310hd1aba9c_0|==2.11.0 cpu_py310hd1aba9c_0|...|==2.9.1 cpu_py310hd1aba9c_0], which requires
       │     └─ python >=3.10,<3.11.0a0 *, which conflicts with any installable versions previously reported;
       ├─ tensorflow-cpu [2.10.0|2.11.0|...|2.9.1] would require
       │  └─ tensorflow [==2.10.0 cpu_py38h66f0ec1_0|==2.11.0 cpu_py38h66f0ec1_0|...|==2.9.1 cpu_py38h66f0ec1_0], which requires
       │     └─ python >=3.8,<3.9.0a0 *, which conflicts with any installable versions previously reported;
       ├─ tensorflow-cpu [2.10.0|2.11.0|...|2.9.1] would require
       │  └─ tensorflow [==2.10.0 cpu_py39h4655687_0|==2.11.0 cpu_py39h4655687_0|...|==2.9.1 cpu_py39h4655687_0], which requires
       │     └─ python >=3.9,<3.10.0a0 *, which conflicts with any installable versions previously reported;
       ├─ tensorflow-cpu [2.12.1|2.13.1|...|2.18.0] would require
       │  └─ tensorflow [==2.12.1 cpu_py311h4b67847_0|==2.12.1 cpu_py311h4b67847_1|...|==2.18.0 cpu_py311h6ac8430_50], which requires
       │     └─ python >=3.11,<3.12.0a0 *, which conflicts with any installable versions previously reported;
       ├─ tensorflow-cpu [2.16.1|2.16.2|2.17.0|2.18.0] would require
       │  └─ tensorflow [==2.16.1 cpu_py312hfe0d8c0_0|==2.16.2 cpu_py312h69ecde4_0|...|==2.18.0 cpu_py312h69ecde4_50], which requires
       │     └─ python >=3.12,<3.13.0a0 *, which conflicts with any installable versions previously reported;
       ├─ tensorflow-cpu [2.18.0|2.19.0|2.19.1] would require
       │  └─ tensorflow [==2.18.0 cpu*_2|==2.18.0 cpu*_52|...|==2.19.1 cpu*_50], which cannot be installed (as previously explained);
       └─ tensorflow-cpu [2.10.0|2.6.0|...|2.9.1] would require
          └─ tensorflow [==2.10.0 cpu_py37h08536eb_0|==2.6.0 cpu_py37hc107814_2|...|==2.9.1 cpu_py37h08536eb_0], which requires
             └─ python >=3.7,<3.8.0a0 *, which conflicts with any installable versions previously reported.
critical libmamba Could not solve for environment specs
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN mamba install -y nltk networkx tensorflow-cpu plotly pymupdf dlib spacy": exit status 1
```